### PR TITLE
Log API client based on config flag

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/PCBridge.kt
+++ b/src/main/kotlin/com/projectcitybuild/PCBridge.kt
@@ -71,8 +71,8 @@ class PCBridge : JavaPlugin() {
 
     private fun createDefaultConfig() {
         config.addDefault<PluginConfig.Settings.MAINTENANCE_MODE>()
-        config.addDefault<PluginConfig.Api.KEY>()
-        config.addDefault<PluginConfig.Api.BASE_URL>()
+        config.addDefault<PluginConfig.API.KEY>()
+        config.addDefault<PluginConfig.API.BASE_URL>()
 
         config.options().copyDefaults(true)
         saveConfig()

--- a/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
@@ -3,9 +3,10 @@ package com.projectcitybuild.entities
 open class PluginConfigPair(val key: String, val defaultValue: Any)
 
 sealed class PluginConfig {
-    sealed class Api {
+    sealed class API {
         class KEY: PluginConfigPair("api.key", defaultValue = "FILL_THIS_IN")
         class BASE_URL: PluginConfigPair("api.base_url", defaultValue = "https://projectcitybuild.com/api/")
+        class IS_LOGGING_ENABLED: PluginConfigPair("api.is_logging_enabled", defaultValue = false)
     }
     sealed class Settings {
         class MAINTENANCE_MODE: PluginConfigPair("settings.maintenance_mode", defaultValue = false)

--- a/src/main/kotlin/com/projectcitybuild/spigot/environment/SpigotEnvironment.kt
+++ b/src/main/kotlin/com/projectcitybuild/spigot/environment/SpigotEnvironment.kt
@@ -80,13 +80,16 @@ class SpigotEnvironment(
     override val apiClient: PCBClient
         get() {
             if (pcbClient == null) {
-                val authToken = get(PluginConfig.Api.KEY()) as? String
+                val authToken = get(PluginConfig.API.KEY()) as? String
                         ?: throw Exception("Could not cast auth token to String")
 
-                val baseUrl = get(PluginConfig.Api.BASE_URL()) as? String
+                val baseUrl = get(PluginConfig.API.BASE_URL()) as? String
                         ?: throw Exception("Could not cast base url to String")
 
-                pcbClient = PCBClient(authToken = authToken, baseUrl = baseUrl)
+                val isLoggingEnabled = get(PluginConfig.API.IS_LOGGING_ENABLED()) as? Boolean
+                        ?: throw Exception("Could not cast is_logging_enabled to Boolean")
+
+                pcbClient = PCBClient(authToken = authToken, baseUrl = baseUrl, withLogging = isLoggingEnabled)
             }
             return pcbClient!!
         }


### PR DESCRIPTION
Changes the API client to only perform logging if `api.is_logging_enabled` is set to `true` in `config.yml`